### PR TITLE
Fixed README.md Markdown Formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Import it into your project like any other garden widget:
 from kivy.garden.joystick import Joystick
 ```
 
-### Widget Properties:  
+## Widget Properties:  
 
 **Joystick Data:**  
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,18 @@ Import it into your project like any other garden widget:
 from kivy.garden.joystick import Joystick
 ```
 
-Then there are 5 settings and 5 outputs:  
+### Widget Properties:  
 
-`background_color`: The color for the whole background of the widget.  
-`perimeter_color`: Color of the perimeter line.  
-`perimeter_line_width`: The width of the perimeter line of the joystick's control area.  
-`pad_color`: Color of the control pad.  
-`pad_width`: Size of the control pad.  
+**Joystick Data:**  
 
-These are the values that you will get out:  
+- `pad_x` & `pad_y`: The percent position of the pad.  
+- `magnitude`: Percent position from origin to perimeter line. mash together with radians or angle to get polar coordinates.  
+- `radians` & `angle`:  The radians/degrees around the joystick that the current position is at. It is solved first for radians, but the angle in degrees is included for simplicity for the implementer.  
 
-`pad_x` & `pad_y`: The percent position of the pad.  
-`magnitude`: Percent position from origin to perimeter line. mash together with radians or angle to get polar coordinates.  
-`radians` & `angle`:  The radians/degrees around the joystick that the current position is at. It is solved first for radians, but the angle in degrees is included for simplicity for the implementer.  
+**Style:**  
+
+- `background_color`: The color for the whole background of the widget.  
+- `perimeter_color`: Color of the perimeter line.  
+- `perimeter_line_width`: The width of the perimeter line of the joystick's control area.  
+- `pad_color`: Color of the control pad.  
+- `pad_width`: Size of the control pad.  

--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
-# Kivy Garden: Joystick
-Joystick Widget, intended to get analog like input from the user via a touch screen. The input can then be used as a control of some sort. 
-![The default joystick coloring example](https://raw.githubusercontent.com/Narcolapser/garden.joystick/master/Joystick screenshot.png)
+# Kivy Garden: Joystick  
 
-## Usage:
+Joystick Widget, intended to get analog like input from the user via a touch screen. The input can then be used as a control of some sort.  
 
-import it into your project like any other garden widget:
+![Example](https://raw.githubusercontent.com/Narcolapser/garden.joystick/master/Joystick%20screenshot.png)  
+
+## Usage:  
+
+Import it into your project like any other garden widget:  
 
 ``` python
 from kivy.garden.joystick import Joystick
 ```
 
-Then there are 5 settings and 5 outputs:
+Then there are 5 settings and 5 outputs:  
 
-background_color: The color for the whole background of the widget.
-perimeter_color: Color of the perimeter line.
-perimeter_line_width: the width of the perimeter line of the joystick's control area.
-pad_color: Color of the control pad
-pad_width: Size of the control pad
+`background_color`: The color for the whole background of the widget.  
+`perimeter_color`: Color of the perimeter line.  
+`perimeter_line_width`: The width of the perimeter line of the joystick's control area.  
+`pad_color`: Color of the control pad.  
+`pad_width`: Size of the control pad.  
 
-These are the values that you will get out:
-pad_x & pad_y: the percent position of the pad. 
+These are the values that you will get out:  
 
-magnitude: Percent position from origin to perimeter line. mash together with radians or angle to get polar coordinates.
-radians & angle: The radians/degrees around the joystick that the current position is at. It is solved first for radians, but the angle in degrees is included for simplicity for the implementer.
+`pad_x` & `pad_y`: The percent position of the pad.  
+`magnitude`: Percent position from origin to perimeter line. mash together with radians or angle to get polar coordinates.  
+`radians` & `angle`:  The radians/degrees around the joystick that the current position is at. It is solved first for radians, but the angle in degrees is included for simplicity for the implementer.  


### PR DESCRIPTION
- fixed image link  
- fixed line spacing for properties  
(*markdown requires 2 spaces at the end of a line, or two newlines in a row, in order for lines to be properly separated*)
- misc formatting  

![joystick](https://user-images.githubusercontent.com/10906415/28428862-b9903adc-6d48-11e7-8a05-079400411e28.png)
